### PR TITLE
fix(hosting) on-demand, e mai la obiect

### DIFF
--- a/_plays/06.md
+++ b/_plays/06.md
@@ -3,11 +3,11 @@ play_number: 6
 title: Alege un plan de hosting flexibil
 ---
 
-Unde e posibil, optează pentru un plan de hosting flexibil, pentru a face față vârfurilor (spike-urilor) de trafic și a putea scala ușor produsul. Ideal, resursele ar fi disponibile la cerere, fără a fi necesară intervenția unui sys-admin. Unde nu e posibilă hostarea în cloud, încearcă să implementezi o arhitectură care ține cont de spike-uri de trafic, disponibilitate a serviciului și plan în caz de disaster recovery.
+Unde e posibil, optează pentru un plan de hosting flexibil, pentru a face față vârfurilor (spike-urilor) de trafic și a putea scala ușor produsul. Ideal, resursele ar fi disponibile la cerere (on-demand, cloud computing), fără a fi necesară intervenția unui sys-admin. Unde nu e posibilă hostarea în cloud, încearcă să implementezi o arhitectură care ține cont de spike-uri de trafic, disponibilitate a serviciului și plan în caz de disaster recovery.
 
 ### Checklist
 
-1. Resursele pot fi provizionate la cerere, sau cu foarte puține formalități
+1. Resursele pot fi provizionate on-demand, sau cu foarte puține [formalități](https://en.wikipedia.org/wiki/Red_tape)
 2. Resursele se pot scala în timp real, în funcție de cerințele utilizatorilor
 3. Ai resurse disponibile în diferite zone / datacentere
 4. Poți proviziona noi resurse printr-un API
@@ -21,7 +21,7 @@ Unde e posibil, optează pentru un plan de hosting flexibil, pentru a face faț�
 - Ce se întâmplă atunci când ai un spike de trafic/load?
 - Câtă capacitate ai în mediul de hosting?
 - Cât timp durează să provizionezi o nouă resursă? (webserver, load balancer, etc.)
-- Poți scala produsul la cerere?
+- Poți scala produsul on-demand?
 - Hostezi produsul în mai multe regiuni/datacentere?
 - În caz de dezastru (întreg datacenter-ul e offline), cât timp durează până când produsul e din nou operațional?
 - Care e impactul unei perioade de inactivitate prelungită?


### PR DESCRIPTION
Actualizat un pic la hosting:
- Intr-adevar, "la cerere" e un termen mai prietenos pentru persoane non-tehnice
- Dar as vrea sa evitam confuzii in randul celor obisnuiti cu notiunea de "on-demand" cand vine vorba de provizionat resurse de computing
- Am pus si un link catre pagina de Wiki pentru [red tape](https://en.wikipedia.org/wiki/Red_tape) ca sa se inteleaga mai clar ce inseamna in contextul de aici, dar am lasat pe romana, formalitati.